### PR TITLE
Add x/y overflow as recognized attributes

### DIFF
--- a/hss/Rules.nml
+++ b/hss/Rules.nml
@@ -182,6 +182,8 @@ var rules = List.concat [[
 	("float",ids ["left";"right";"none"]);
 	("clear",ids ["none";"left";"right";"both"]);
 	("overflow",ids ["auto";"hidden";"scroll";"visible"]);
+    ("overflow-x",ids ["auto";"hidden";"scroll";"visible"]);
+    ("overflow-y",ids ["auto";"hidden";"scroll";"visible"]);
 	("position",ids ["absolute";"fixed";"relative";"static"]);
 	("z-index",[RInt;RId "auto"]);
 	("visibility",ids ["visible";"hidden"]);


### PR DESCRIPTION
Exactly as per commit title. Ran into this as an issue while restyling CastleDB to be more tolerant of small window sizes (scrolling layers list).