### PR TITLE
add Op("&") for nested blocks

### DIFF
--- a/hss/Ast.nml
+++ b/hss/Ast.nml
@@ -91,6 +91,7 @@ type operator {
 	OpDefault;
 	OpChild;
 	OpPreceding : bool;
+	OpJoint;
 }
 
 type attrib_op {

--- a/hss/Lexer.nml
+++ b/hss/Lexer.nml
@@ -104,7 +104,7 @@ expr := Lexer.build (List.concat [[
 	("-?[0-9]+.[0-9]*", mk_float);
 	("-?.[0-9]+", mk_float);
 	(ident, function(l) { mk_ident l });
-	("@media [^{]*", function(l) { 
+	("@media [^{]*", function(l) {
 		var i = Lexer.current l;
 		mk l Media(String.sub i 7 (String.length i - 7))
 	});

--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -112,7 +112,11 @@ function rec print_class(ch,c) {
 	match c.sub {
 	| None -> ()
 	| Some cs ->
-		IO.write ch (match c.operator { OpDefault -> " " | OpChild -> ">" | OpPreceding imm -> if imm then "+" else "~" });
+		IO.write ch (match c.operator {
+		| OpDefault | OpJoint -> if cs.operator == OpJoint then "" else " "
+		| OpChild -> ">"
+		| OpPreceding imm -> if imm then "+" else "~"
+		});
 		print_class ch cs
 	}
 }
@@ -192,11 +196,11 @@ function rec flatten(parents,e) {
 		| _ -> (EBlock classes attribs,snd e) :: el
 		}
 	| EMedia (str,el) ->
-		[(EMedia(str, List.concat (List.map (flatten parents) el)),snd e)]	
+		[(EMedia(str, List.concat (List.map (flatten parents) el)),snd e)]
 	| EInclude s ->
 		var s = match parents {
 			| [] -> s
-			| l -> 
+			| l ->
 				var ch, out = IO.write_string();
 				List.iter (function(c) { print_class ch c; IO.write ch " "; }) l;
 				out() + s
@@ -452,7 +456,7 @@ function rec eval_block(ctx,b) {
 	| EMedia (str,el) ->
 		(EMedia str (List.map (eval_block ctx) el), snd b)
 	| _ ->
-		b	
+		b
 	}
 }
 

--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -261,6 +261,14 @@ function rec class(s,first) {
 			| DoubleDot when *last == None && c.selector == None ->
 				last := Some DoubleDot;
 				loop (i+1)
+			| Op And when i == 0 && first ->
+				match fst (stream_token s 1){
+				| Dot | DoubleDot ->
+					c.operator := OpJoint;
+					stream_junk s 1;
+					loop 0
+				| _ -> i
+				}
 			| BracketOpen when *last == None ->
 				match fst (stream_token s (i+1)) {
 				| Const (Ident att) ->


### PR DESCRIPTION
hss:

```css
a {
	color: #000;
	&:hover{
		color:#fff;
		&:before{
			color:#000;
		}
		.add{
			color:#000;
		}
	}

	&.tit{
		color:#000;
	}

	.normal{
		color:#fff;
		&.join{
			color: #000;
		}
	}
}

&.hover{
	color: #f00;
}
```

output:

```css
a {
	color : #000;
}
a:hover {
	color : #fff;
}
a:hover:before {
	color : #000;
}
a:hover .add {
	color : #000;
}
a.tit {
	color : #000;
}
a .normal {
	color : #fff;
}
a .normal.join {
	color : #000;
}
.hover {
	color : #f00;
}
```