### PR TITLE
add @import for inject .hss/css

### DIFF
--- a/hss/Ast.nml
+++ b/hss/Ast.nml
@@ -123,6 +123,7 @@ type expr_decl {
 	ESub : expr list;
 	EMedia : (string, expr list);
 	EInclude : string;
+	EImport : string;
 }
 
 type expr = (expr_decl , pos)

--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -153,6 +153,9 @@ function rec print_css(ch,tabs,e) {
 		IO.write ch tabs;
 		IO.write ch s;
 		IO.write ch "\n";
+	| EImport s ->
+		IO.write ch s;
+		IO.write ch "\n";
 	}
 }
 
@@ -206,6 +209,9 @@ function rec flatten(parents,e) {
 				out() + s
 		}
 		[(EInclude s,snd e)]
+	| EImport s ->
+		if parents != [] then error "@import(\".css\") Only works on the top" snd(e);
+		[(EImport s ,snd e)]
 	}
 }
 
@@ -743,6 +749,18 @@ function rec check(ctx,e) {
 		(EMedia m (List.map (check ctx) el), snd e)
 	| EInclude _ ->
 		e
+	| EImport s ->
+		if String.sub(s, String.length(s) - 4, 4) != ".css" then {
+			var file = if String.sub(s, String.length(s) - 4, 4) == ".hss" then s else s + ".hss";
+			var ch = IO.read_file file true;
+			var lex = Lexer.create Buffer.create();
+			Lexer.input lex file ch 1 0;
+			var el = Hss.Parser.parse lex;
+			IO.close_in ch;
+			(ESub (List.map (check ctx) el),snd e)
+		} else {
+			(EImport IO.file_contents(s), snd e)
+		}
 	}
 }
 

--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -750,16 +750,31 @@ function rec check(ctx,e) {
 	| EInclude _ ->
 		e
 	| EImport s ->
-		if String.sub(s, String.length(s) - 4, 4) != ".css" then {
-			var file = if String.sub(s, String.length(s) - 4, 4) == ".hss" then s else s + ".hss";
-			var ch = IO.read_file file true;
-			var lex = Lexer.create Buffer.create();
-			Lexer.input lex file ch 1 0;
-			var el = Hss.Parser.parse lex;
-			IO.close_in ch;
-			(ESub (List.map (check ctx) el),snd e)
+		var p = snd e;
+		var parent = Hss.Path.find(Lexer.source p);
+		var file = if Hss.Path.isabs(s) then s else (if parent.dir == "" then s else parent.dir + "/" + s);
+		var path = Hss.Path.make(file);
+		if !Hss.Path.duplicate(path) then {
+			Hss.Path.add(path);
+			match path.ext {
+			| "hss"	->
+				var ch = try (IO.read_file path.full true) catch {
+				| err -> error("ERROR: " + (string err), p)
+				}
+				var lex = Lexer.create Buffer.create();
+				Lexer.input lex path.full ch 1 0;
+				var el = Hss.Parser.parse lex;
+				IO.close_in ch;
+				(ESub (List.map (check ctx) el), p)
+			| "css" ->
+				try (EImport IO.file_contents(path.full), p) catch {
+				| err -> error("ERROR: " + (string err), p)
+				}
+			| _ ->
+				error("Unsupported type (." + path.ext + ")", p)
+			}
 		} else {
-			(EImport IO.file_contents(s), snd e)
+			(ESub [], p) // duplicate, simply ignore it;
 		}
 	}
 }
@@ -769,7 +784,7 @@ function display(msg,p) {
 		Stack.dump IO.stderr Stack.exc();
 		IO.printf IO.stderr "Exception : %s\n" msg
 	} else
-	IO.printf IO.stderr "%s:%d: %s\n" (Lexer.source p,Lexer.line p,msg);
+	IO.printf IO.stderr "%s:%d: %s\n" (Hss.Path.full2rel(Lexer.source p),Lexer.line p,msg);
 }
 
 function report(msg,p) {
@@ -788,8 +803,10 @@ try {
 	List.iter (function(file) {
 		// parse
 		var ch = IO.read_file file true;
+		var path = Hss.Path.make(file);
+		Hss.Path.refresh(path);
 		var lex = Lexer.create Buffer.create();
-		Lexer.input lex file ch 1 0;
+		Lexer.input lex path.full ch 1 0;
 		var el = Hss.Parser.parse lex;
 		IO.close_in ch;
 		// check + replace vars

--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -154,7 +154,11 @@ function rec print_css(ch,tabs,e) {
 		IO.write ch s;
 		IO.write ch "\n";
 	| EImport s ->
-		IO.write ch s;
+		try {
+			IO.write ch IO.file_contents(s)
+		} catch {
+		| err -> error("ERROR: " + (string err), snd e)
+		}
 		IO.write ch "\n";
 	}
 }
@@ -767,9 +771,7 @@ function rec check(ctx,e) {
 				IO.close_in ch;
 				(ESub (List.map (check ctx) el), p)
 			| "css" ->
-				try (EImport IO.file_contents(path.full), p) catch {
-				| err -> error("ERROR: " + (string err), p)
-				}
+				(EImport file, p)
 			| _ ->
 				error("Unsupported type (." + path.ext + ")", p)
 			}

--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -63,6 +63,9 @@ function rec expr(s) {
 		| [< v = value s; p2 = semicolon s >] -> (EVar i v, punion p1 p2)
 		}
 	| [< (Const (Ident "@include"),p1); (ParentOpen,_); (Const (String s),_); (ParentClose,p2) >] -> (EInclude s, punion p1 p2)
+	| [< (Const (Ident "@import" ),p1); (ParentOpen,_); (Const (String f),_); (ParentClose,p2) >] when f != "" ->
+		if (fst (stream_token s 0) == Semicolon) then (stream_junk s 1); // "for syntax highlighting/completion of some IDE
+		(EImport f, punion p1 p2)
 	| [< (Media str,p1); (BraceOpen,_); l = expr_list s; >] -> (EMedia str l, p1)
 	| [< c = class_list s true; (BraceOpen,p); l = expr_list s; >] -> (EBlock c l, p)
 	}

--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -64,7 +64,7 @@ function rec expr(s) {
 		}
 	| [< (Const (Ident "@include"),p1); (ParentOpen,_); (Const (String s),_); (ParentClose,p2) >] -> (EInclude s, punion p1 p2)
 	| [< (Const (Ident "@import" ),p1); (ParentOpen,_); (Const (String f),_); (ParentClose,p2) >] when f != "" ->
-		if (fst (stream_token s 0) == Semicolon) then (stream_junk s 1); // "for syntax highlighting/completion of some IDE
+		if (fst (stream_token s 0) == Semicolon) then (stream_junk s 1); // for syntax highlighting/completion of some IDE
 		(EImport f, punion p1 p2)
 	| [< (Media str,p1); (BraceOpen,_); l = expr_list s; >] -> (EMedia str l, p1)
 	| [< c = class_list s true; (BraceOpen,p); l = expr_list s; >] -> (EBlock c l, p)

--- a/hss/Path.nml
+++ b/hss/Path.nml
@@ -1,0 +1,112 @@
+/*
+ *  Hss Format
+ *  Copyright (c)2008 Nicolas Cannasse
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License or the LICENSE file for more details.
+ */
+
+type path {
+	dir : string; // without trailing slash
+	name: string;
+	ext : string;
+	full: string;
+}
+
+var file_full_path: string -> string = neko("$loader.loadprim('std@file_full_path',1)");
+var imports: path list ref = &[];
+
+function lastchar(s: string, c: char, i: int): int {
+	function rec loop(i)	{
+		if i < 0 then -1
+		else if String.get(s, i) == c then i
+		else loop(i - 1)
+	}
+	loop(i)
+}
+
+function without_extension(s) {
+	if s != "" then {
+		var cp = lastchar(s, '.', (String.length s) - 1);
+		if cp == -1 then s else String.sub(s, 0, cp)
+	} else
+		s
+}
+
+function isabs(s) {
+	match String.length s {
+	| 0 -> false
+	| 1 -> '/' == String.get(s, 0)
+	| _ -> ':' == String.get(s, 1) || '/' == String.get(s, 0)
+	}
+}
+
+function duplicate(path) {
+	function cmp(p1, p2) {
+		without_extension(p1.full) == without_extension(p2.full)
+	}
+	function rec loop(l) {
+		match l {
+		| [] -> false
+		| x::tl -> if cmp(x, path) then true else loop(tl)
+		}
+	}
+	loop(*imports)
+}
+
+function add(path) {
+	imports := path::(*imports);
+}
+
+function refresh(init) {
+	imports := [init];
+}
+
+function find(full) {
+	function rec loop(l){
+		match l {
+		| [] -> throw Not_found
+		| x::tl -> if x.full == full then x else loop(tl)
+		}
+	}
+	loop(*imports)
+}
+
+function rel_path(path) {
+	(if path.dir == "" then path.name else (path.dir + "/" + path.name)) + "." + path.ext
+}
+
+function full2rel(full) {
+	rel_path(find full)
+}
+
+function make(s: string) {
+	var last = String.length(s) - 1;
+	var c1, c2 = (lastchar(s, '/' , last), lastchar(s, '\\', last))
+	var dir, name = if c1 < c2 then
+		(String.sub(s, 0, c2), String.sub(s, c2 + 1, last - c2))
+	else if c2 < c1 then
+		(String.sub(s, 0, c1), String.sub(s, c1 + 1, last - c1))
+	else
+		("", s)
+
+	var last = String.length(name) - 1;
+	var cp = lastchar(name, '.' , last);
+	var full, ext, name = if cp != -1 then
+		(s, String.sub(name, cp + 1, last - cp), String.sub(name, 0, cp))
+	else
+		(s + ".hss", "hss", name)
+	{
+		dir  = dir;
+		name = name;
+		ext  = ext;
+		full = file_full_path(full);
+	}
+}


### PR DESCRIPTION
It works well for me, but the code maybe not pretty good.
- duplicate/recursive reference file Will be simply ignored.
- Correctly handle paths.(relative to the current file)

A.hss
```scss
@import("reset.css"); // directly inject css file
@import("vars");      // import "vars.hss"
.A {
    color: $blue;
    background: $white;
}
@import("B");
@import("C");
@import("B");         // duplicate. will be ignored.
```
B.hss
```scss
@import("vars");      // ignored. becourse it have has imported by "A.hss"
.B {
    color: $blue;
}
```
C.hss
```scss
.C {
    color: $blue;     // importd by "A.hss"
}
@import("A");         // recursive reference, only simply ignored.
```
vars.hss
```scss
var blue  = #00f;
var white = #fff;
```
reset.css
```css
[tabindex="-1"]:focus {
    outline: none !important;
}
```
generated: `neko hss.n A.hss`
```css
[tabindex="-1"]:focus {
  outline: none !important;
}
.A {
    color : #00f;
    background : #fff;
}
.B {
    color : #00f;
}
.C {
    color : #00f;
}
```