### PR TITLE
fix Op("&") when it was been overwritten

### DIFF
--- a/hss/Ast.nml
+++ b/hss/Ast.nml
@@ -91,7 +91,6 @@ type operator {
 	OpDefault;
 	OpChild;
 	OpPreceding : bool;
-	OpJoint;
 }
 
 type attrib_op {
@@ -112,6 +111,7 @@ type class {
 	mutable sub : class option;
 	mutable attributes : (string,attrib_op) list;
 	mutable operator : operator;
+	mutable joint: bool;
 }
 
 type expr_decl {

--- a/hss/Ast.nml
+++ b/hss/Ast.nml
@@ -91,6 +91,7 @@ type operator {
 	OpDefault;
 	OpChild;
 	OpPreceding : bool;
+	OpJoint;
 }
 
 type attrib_op {
@@ -111,7 +112,6 @@ type class {
 	mutable sub : class option;
 	mutable attributes : (string,attrib_op) list;
 	mutable operator : operator;
-	mutable joint: bool;
 }
 
 type expr_decl {

--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -92,7 +92,14 @@ function att_op_str(op) {
 	}
 }
 
-function rec print_class(ch,c) {
+function rec print_class(first,ch,c) {
+	if !first then
+		IO.write ch (match c.operator {
+		| OpDefault -> " "
+		| OpChild -> ">"
+		| OpPreceding imm -> if imm then "+" else "~"
+		| OpJoint -> ""
+		})
 	match c.node {
 	| None -> ()
 	| Some id -> IO.write ch id;
@@ -112,12 +119,7 @@ function rec print_class(ch,c) {
 	match c.sub {
 	| None -> ()
 	| Some cs ->
-		IO.write ch (match c.operator {
-		| OpDefault -> if cs.joint == false then " " else ""
-		| OpChild -> ">"
-		| OpPreceding imm -> if imm then "+" else "~"
-		});
-		print_class ch cs
+		print_class false ch cs;
 	}
 }
 
@@ -137,7 +139,7 @@ function rec print_css(ch,tabs,e) {
 		IO.write ch ";\n";
 	| EBlock(classes,el) ->
 		IO.write ch tabs;
-		print_sep ", " print_class ch classes;
+		print_sep ", " (print_class true) ch classes;
 		IO.write ch " {\n";
 		List.iter (print_css ch (tabs+"\t")) el;
 		IO.printf ch "%s}\n" tabs;
@@ -168,7 +170,6 @@ function rec make_sub(p,c) {
 			| None -> Some c
 			| Some p -> Some (make_sub p c)
 		};
-		joint = p.joint;
 	}
 }
 
@@ -203,7 +204,7 @@ function rec flatten(parents,e) {
 			| [] -> s
 			| l ->
 				var ch, out = IO.write_string();
-				List.iter (function(c) { print_class ch c; IO.write ch " "; }) l;
+				List.iter (function(c) { print_class true ch c; IO.write ch " "; }) l;
 				out() + s
 		}
 		[(EInclude s,snd e)]

--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -113,7 +113,7 @@ function rec print_class(ch,c) {
 	| None -> ()
 	| Some cs ->
 		IO.write ch (match c.operator {
-		| OpDefault | OpJoint -> if cs.operator == OpJoint then "" else " "
+		| OpDefault -> if cs.joint == false then " " else ""
 		| OpChild -> ">"
 		| OpPreceding imm -> if imm then "+" else "~"
 		});
@@ -168,6 +168,7 @@ function rec make_sub(p,c) {
 			| None -> Some c
 			| Some p -> Some (make_sub p c)
 		};
+		joint = p.joint;
 	}
 }
 

--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -217,7 +217,7 @@ function rec value_hex(p,s) {
 }
 
 function rec class(s,first) {
-	var c = { node = None; id = None; classes = []; sub = None; selector = None; attributes = []; operator = OpDefault; joint = false; };
+	var c = { node = None; id = None; classes = []; sub = None; selector = None; attributes = []; operator = OpDefault; };
 	var pos = &null_pos;
 	var last = &None;
 	function rec loop(i) {
@@ -261,14 +261,6 @@ function rec class(s,first) {
 			| DoubleDot when *last == None && c.selector == None ->
 				last := Some DoubleDot;
 				loop (i+1)
-			| Op And when i == 0 ->
-				match fst (stream_token s 1){
-				| Dot | DoubleDot ->
-					c.joint := true;
-					stream_junk s 1;
-					loop 0
-				| _ -> i
-				}
 			| BracketOpen when *last == None ->
 				match fst (stream_token s (i+1)) {
 				| Const (Ident att) ->
@@ -313,6 +305,17 @@ function rec class(s,first) {
 				i
 		}
 	}
+	match s {
+	| [< (Gt,_) >] -> c.operator := OpChild
+	| [< (Tild,_) >] -> c.operator := OpPreceding false
+	| [< (Op Add,_) >] -> c.operator := OpPreceding true
+	| [< (Op And,p) >] ->
+		match fst (stream_token s 0) {
+		| Dot | DoubleDot | BracketOpen -> c.operator := OpJoint
+		| _ -> error Unexpected(Op And) p
+		}
+	| [< >] -> ()
+	}
 	var n = loop 0;
 	if n == 0 && c.attributes == [] then error (if first then Unexpected fst(stream_token s 0) else Class_expected) (*pos);
 	c.attributes := List.rev c.attributes;
@@ -320,13 +323,6 @@ function rec class(s,first) {
 	match *last {
 	| None -> ()
 	| Some t -> error (Unexpected t) (*pos);
-	}
-	match s {
-	| [< (Gt,_) >] -> c.operator := OpChild
-	| [< (Tild,_) >] -> c.operator := OpPreceding false
-	| [< (Op Add,_) >] -> c.operator := OpPreceding true
-	| [< (Op And,p) >] -> error Unexpected(Op And) p
-	| [< >] -> ()
 	}
 	try
 		c.sub := Some (class s false)

--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -217,7 +217,7 @@ function rec value_hex(p,s) {
 }
 
 function rec class(s,first) {
-	var c = { node = None; id = None; classes = []; sub = None; selector = None; attributes = []; operator = OpDefault; };
+	var c = { node = None; id = None; classes = []; sub = None; selector = None; attributes = []; operator = OpDefault; joint = false; };
 	var pos = &null_pos;
 	var last = &None;
 	function rec loop(i) {
@@ -264,7 +264,7 @@ function rec class(s,first) {
 			| Op And when i == 0 && first ->
 				match fst (stream_token s 1){
 				| Dot | DoubleDot ->
-					c.operator := OpJoint;
+					c.joint := true;
 					stream_junk s 1;
 					loop 0
 				| _ -> i

--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -261,7 +261,7 @@ function rec class(s,first) {
 			| DoubleDot when *last == None && c.selector == None ->
 				last := Some DoubleDot;
 				loop (i+1)
-			| Op And when i == 0 && first ->
+			| Op And when i == 0 ->
 				match fst (stream_token s 1){
 				| Dot | DoubleDot ->
 					c.joint := true;
@@ -325,6 +325,7 @@ function rec class(s,first) {
 	| [< (Gt,_) >] -> c.operator := OpChild
 	| [< (Tild,_) >] -> c.operator := OpPreceding false
 	| [< (Op Add,_) >] -> c.operator := OpPreceding true
+	| [< (Op And,p) >] -> error Unexpected(Op And) p
 	| [< >] -> ()
 	}
 	try


### PR DESCRIPTION
In the following css, the `Op(">")` will override the **`&`**.
```sass
a{
  &:hover > li { 
    color: #000
  }
}
```
