### PR TITLE
add rgb-hsl for darken/lighten color...

### DIFF
--- a/hss/Main.nml
+++ b/hss/Main.nml
@@ -304,6 +304,93 @@ function get_rule(ctx,name) {
 	}
 }
 
+function hsl2rgb(h:float, s:float, l:float) {
+	if (s <= 0.) then {
+		var r = Math.round((max 0. (min 1. l)) * 255);
+		(r, r, r)
+	} else {
+		function hue2rgb(p: float, q:float, t: float) {
+			var t = if t < 0. then t + 1. else t;
+			var t = if t > 1. then t - 1. else t;
+			if t < 1/6. then
+				p + (q - p) * 6. * t
+			else if t < 1/2. then
+				q
+			else if t < 2/3. then
+				p + (q - p) * (2/3. - t) * 6.
+			else
+				p
+		}
+		var q = if l < 0.5 then l * (1. + s) else l + s - l * s;
+		var p = 2. * l - q;
+		var r = max 0. (min 1. hue2rgb(p, q, h + 1/3.));
+		var g = max 0. (min 1. hue2rgb(p, q, h));
+		var b = max 0. (min 1. hue2rgb(p, q, h - 1/3.));
+		(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
+	}
+}
+
+function rgb2hsl(ir: int, ig: int, ib: int) {
+	var r = max 0. min(1., ir / 255.);
+	var g = max 0. min(1., ig / 255.);
+	var b = max 0. min(1., ib / 255.);
+	var max = max(max(r, g), b);
+	var min = min(min(r, g), b);
+	var l = (max + min) / 2.;
+	if (max == min) then
+		(0., 0., l)
+	else {
+		var d = max - min;
+		var s = if l > 0.5 then d / (2 - max - min) else d / (max + min);
+
+		var h = if max == r then
+			(g - b) / d + (if g < b then 6. else 0.)
+		else if max == g then
+			(b - r) / d + 2.
+		else
+			(r - g) / d + 4.;
+		(h/6., s, l)
+	}
+}
+
+function ofhex(h, v) {
+	match String.length h {
+	| 3 ->
+		var r = int ("0x" + String.sub h 0 1);
+		var g = int ("0x" + String.sub h 1 1);
+		var b = int ("0x" + String.sub h 2 1);
+		(r * 16 + r,g*16+g,b*16+b)
+	| 6 ->
+		(int ("0x" + String.sub h 0 2), int ("0x" + String.sub h 2 2), int ("0x" + String.sub h 4 2))
+	| _ ->
+		error ("Invalid 'color' value #" + h) v;
+	}
+}
+
+function custom_calls(v1, vl) {
+	function adjust(hex, hp, dh, ds, dl) {
+		var r, g, b = ofhex hex hp;
+		var h, s, l = rgb2hsl r g b;
+		var r, g, b = hsl2rgb(h + dh, s + ds, l + dl);
+		VHex (sprintf "%.6X" ((r << 16) or (g << 8) or b))
+	}
+	match (v1, vl) {
+	| ((VIdent "lighten", _),[(VHex h, hp); (VUnit(i, "%"), _)]) ->
+		Some adjust(h, hp, 0., 0.,  i/100.)
+	| ((VIdent "darken", _), [(VHex h, hp); (VUnit(i, "%"), _)]) ->
+		Some adjust(h, hp, 0., 0., -i/100.)
+	| ((VIdent "saturate", _), [(VHex h, hp); (VUnit(i, "%"), _)]) ->
+		Some adjust(h, hp, 0.,  i/100., 0.)
+	| ((VIdent "desaturate",_),[(VHex h, hp); (VUnit(i, "%"), _)]) ->
+		Some adjust(h, hp, 0., -i/100., 0.)
+	| ((VIdent "invert",_),[(VHex h, hp)]) ->
+		var r, g, b = ofhex h hp;
+		var r, g, b = (255 - r, 255 - g, 255 - b);
+		Some VHex(sprintf "%.6X" ((r << 16) or (g << 8) or b))
+	| _ -> None;
+	}
+}
+
 function rec eval(ctx,v) {
 	match fst v {
 	| VIdent _
@@ -325,7 +412,12 @@ function rec eval(ctx,v) {
 		ctx.eval_rec := ctx.eval_rec - 1;
 		r
 	| VCall(v1,vl) ->
-		(VCall (eval ctx v1) (List.map (eval ctx) vl),snd v)
+		var v1 = eval ctx v1;
+		var vl = List.map (eval ctx) vl;
+		match custom_calls v1 vl {
+		| Some(vhex) -> (vhex, snd v)
+		| None -> (VCall v1 vl,snd v)
+		}
 	| VLabel (l,v1) ->
 		(VLabel l (eval ctx v1), snd v)
 	| VBind(name,v1) ->
@@ -355,22 +447,13 @@ function rec eval(ctx,v) {
 			| (VFloat x, VUnit (y,u)) -> VUnit (fop x y) u
 			| (VHex c, VFloat a) ->
 				// assume color operation
-				var rgb = match String.length c {
-					| 3 ->
-						var rgb = int ("0x" + c);
-						var rgb = ((rgb and 0xF) or ((rgb and 0xF0) << 4) or ((rgb and 0xF00) << 8));
-						rgb or (rgb << 4)
-					| 6 -> int ("0x" + c)
-					| _ -> error "Operation not allowed" snd(v)
-				}
 				function color(c:int) {
 					var c = Math.round (fop (c * 1.0) a);
 					if c < 0 then 0 else if c > 255 then 255 else c;
 				}
-				var r = color (rgb and 0xFF);
-				var g = color ((rgb >> 8) and 0xFF);
-				var b = color (rgb >> 16);
-				VHex (sprintf "%.6X" (r or (g << 8) or (b << 16)))
+				var r, g, b = ofhex(c, snd v1);
+				var r, g, b = (color r, color g, color b);
+				VHex (sprintf "%.6X" ((r << 16) or (g << 8) or b))
 			| (_,VLabel (l,v)) ->
 				VLabel l (loop v1 v, snd v)
 			| _ ->
@@ -464,14 +547,7 @@ function rec expand_val(value) {
 	var p = snd value;
 	match fst value {
 	| VCall((VIdent "rgba",_) as c,[(VHex h,hp);(VFloat f,fp)]) ->
-		var r, g, b = if String.length h == 3 then {
-			var r = int ("0x" + String.sub h 0 1);
-			var g = int ("0x" + String.sub h 1 1);
-			var b = int ("0x" + String.sub h 2 1);
-			(r * 16 + r,g*16+g,b*16+b)
-		} else {
-			(int ("0x" + String.sub h 0 2), int ("0x" + String.sub h 2 2), int ("0x" + String.sub h 4 2))
-		}
+		var r, g, b = ofhex h hp;
 		var params = [(VInt r,hp);(VInt g,hp);(VInt b,hp);(VFloat f,fp)];
 		expand_val (VCall c params, p)
 	| VCall (v,vl) ->


### PR DESCRIPTION
- added `darken/lighten/saturate/desaturate/invert`

I think this is useful to copy style from others sass/less 😄 

```scss
a {
  color: darken(#56789a, 5%);
  background: lighten(invert(#987), 15%);
  border: 1px solid saturate(desaturate(#abc, 10%), 20%);
}
```
generated by HSS
```css
a {
	color: #4D6B8A;
	background: #8F9DAB;
	border: 1px solid #A3BBD3;
}
```
by SASS:
```css
a {
  color: #4d6b8a;
  background: #8f9dab;
  border: 1px solid #a3bbd3; }
```