### PR TITLE
correctly parse the "VOp(op, v1, v2)"

### DIFF
--- a/hss/Parser.nml
+++ b/hss/Parser.nml
@@ -99,24 +99,23 @@ function rec value(s) {
 			value_next (VIdent i,p1) s
 		}
 	| [< (Const (String str),p) >] -> value_next (VString str,p) s
-	| [< (Const (Int i),p) >] -> value_unit (i * 1.0) Some(i) p s
-	| [< (Const (Float f),p) >] -> value_unit f None p s
+	| [< (Const (Int i),p) >] -> value_unit (i * 1.0) (VInt i, p) s
+	| [< (Const (Float f),p) >] -> value_unit f (VFloat f, p) s
 	| [< (Const (Val v),p) >] -> value_next (VVar v,p) s
 	}
 }
 
-function rec value_unit(f,i,p,s) {
-	var v = match s {
-	| [< (Const (Ident i),_) >] ->
-		(VUnit f i, p)
-	| [< (Percent,_) >] ->
-		(VUnit f "%", p)
-	| [< >] ->
-		match i {
-		| None -> (VFloat f, p)
-		| Some i -> (VInt i, p)
+function rec value_unit(f,v,s) {
+	var p = snd v;
+	var p2 = snd (stream_token s 0);
+	var v = if p2.pmin == p.pmax then
+		match s {
+		| [< (Const (Ident i),_) >] -> (VUnit f i, p)
+		| [< (Percent,_) >] -> (VUnit f "%", p)
+		| [< >] -> v
 		}
-	}
+	else
+		v;
 	value_next v s
 }
 
@@ -152,7 +151,11 @@ function rec value_next(v,s) {
 		}
 		loop v2
 	| [< (Op o,_); v2 = value s >] ->
-		(VOp o v v2, punion (pos v) (pos v2))
+		match v2 {
+		| (VList x::tl, lp) -> (VList ((VOp o v x, punion (pos v) (pos v2))::tl), punion (pos v) lp)
+		| (VGroup x::tl, lp)-> (VGroup((VOp o v x, punion (pos v) (pos v2))::tl), punion (pos v) lp)
+		| _-> (VOp o v v2, punion (pos v) (pos v2))
+		}
 	| [< >] ->
 		v
 	}


### PR DESCRIPTION
```sass
a {
  color: rgba(#fff * 0.8, 0.6);
}
```
the above code will be parse as: 
```ocaml
VCall("rgba", VOp("*", #fff, VList[0.8; 0.6]))
```
after this pr:
```ocaml
VCall("rgba", VList[VOp("*", #fff, 0.8); 0.6])
```

example: style.hss

```sass
a {
  color: rgba(#fff * 0.8, 0.6);
  background: #567 * 0.8 + 1.0 url("bg.png");
  border: 1px + 2 + 3 + 4 solid #ccc;
}
```
neko hss.n style.hss
```css
a {
	color : #CCCCCC;
	color : rgba(204,204,204,0.6);
	background : #99B8D6 url("bg.png");
	border : 10px solid #ccc;
}
```